### PR TITLE
Typo fix for "FileNotFoundError" error message

### DIFF
--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -82,7 +82,7 @@ class Gmail(object):
 
         except InvalidClientSecretsError:
             raise FileNotFoundError(
-                "Your 'client_secrets.json' file is nonexistent. Make sure "
+                "Your 'client_secret.json' file is nonexistent. Make sure "
                 "the file is in the root directory of your application. If "
                 "you don't have a client secrets file, go to https://"
                 "developers.google.com/gmail/api/quickstart/python, and "


### PR DESCRIPTION
Fixed typo in raised "FileNotFoundError" exception message. The needed file is "client_secret.json", not "client_secrets.json".
This is consistent with the documentation, which refers to "client_secret.json" (for example Step 6 under "Getting Started").