### PR TITLE
Fix bug caused by unhandled 'KeyError' exception

### DIFF
--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -619,11 +619,10 @@ class Gmail(object):
         else:
             msg_id = message['id']
             thread_id = message['threadId']
-            user_labels = {x.id: x for x in self.list_labels(user_id=user_id)}
-            try:
-                label_ids = [user_labels[x] for x in message['labelIds']
-            except KeyError:
-                label_ids = []
+            label_ids = []
+            if 'labelIds' in message:
+                user_labels = {x.id: x for x in self.list_labels(user_id=user_id)}
+                label_ids = [user_labels[x] for x in message['labelIds']]
             snippet = html.unescape(message['snippet'])
 
             payload = message['payload']

--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -620,7 +620,10 @@ class Gmail(object):
             msg_id = message['id']
             thread_id = message['threadId']
             user_labels = {x.id: x for x in self.list_labels(user_id=user_id)}
-            label_ids = [user_labels[x] for x in message['labelIds']]
+            try:
+                label_ids = [user_labels[x] for x in message['labelIds']
+            except KeyError:
+                label_ids = []
             snippet = html.unescape(message['snippet'])
 
             payload = message['payload']


### PR DESCRIPTION
This commit fixes a KeyError bug in gmail.py.

Explanation of the bug: when using the get_messages function, by default, no labels are passed on. However the message is parsed for attached labels, and those are passed if found. The vast majority of messages have at least one label (e.g. "INBOX"), however in some rare cases a message might be left without any labels attached.  In those cases, no labels can be passed on, eventually causing a KeyError to occur at line 623 (KeyError: 'labelIds') under the internal function _build_message_from_ref.

Fix: This commit fixes the KeyError bug by adding appropriate exception handling. If a KeyError is raised in _build_message_from_ref, it is handled by giving label_ids an empty list [] instead.